### PR TITLE
Upgrade vLLM dependency to 0.11.0 for CUDA 12+ (Blackwell)

### DIFF
--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/deepseek_ocr.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/deepseek_ocr.py
@@ -2,7 +2,7 @@
 """Inference-only Deepseek-OCR model compatible with HuggingFace weights."""
 import math
 from collections.abc import Iterable, Mapping, Sequence
-from typing import List, Literal, Optional, Set, Tuple, TypedDict, Union
+from typing import List, Literal, Optional, Set, Tuple, TypedDict, Union, Mapping
 
 import torch
 import torch.nn as nn
@@ -11,12 +11,11 @@ from einops import rearrange, repeat
 from transformers import BatchFeature
 
 from vllm.config import VllmConfig
-from vllm.model_executor import SamplingMetadata
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.model_loader.utils import set_default_torch_dtype
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (MultiModalDataDict, MultiModalFieldConfig,
-                                    MultiModalKwargs, NestedTensors)
+                                    MultiModalKwargs, MultiModalUUIDDict, NestedTensors)
 from vllm.multimodal.parse import (ImageEmbeddingItems, ImageProcessorItems,
                                    ImageSize, MultiModalDataItems)
 from vllm.multimodal.processing import (BaseMultiModalProcessor,
@@ -156,15 +155,17 @@ class DeepseekOCRMultiModalProcessor(
         prompt: str,
         mm_data: Mapping[str, object],
         mm_kwargs: Mapping[str, object],
+        tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
-        
-        
-        # print(mm_data)
         if mm_data:
-            processed_outputs = self.info.ctx.call_hf_processor(
-                self.info.get_hf_processor(**mm_kwargs),
-                dict(prompt=prompt, **mm_data),
-                mm_kwargs,
+            # Call the processor directly with correct arguments
+            hf_processor = self.info.get_hf_processor(**mm_kwargs)
+            # Convert the old-style call to the new signature
+            mm_data_dict = {"image": mm_data.get("images", [])} if "images" in mm_data else mm_data
+            processed_outputs = hf_processor(
+                prompt=prompt,
+                mm_data=mm_data_dict,
+                hf_processor_mm_kwargs=mm_kwargs,
             )
 
         else:
@@ -233,6 +234,8 @@ class DeepseekOCRMultiModalProcessor(
         prompt: Union[str, list[int]],
         mm_data_items: MultiModalDataItems,
         hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs:Mapping[str, object],
+        mm_uuids: Optional[MultiModalUUIDDict] = None,
     ) -> tuple[list[int], MultiModalKwargs, bool]:
         # The processor logic is different for len(images) <= 2 vs > 2
         # Since the processing cache assumes that the processor output is
@@ -244,13 +247,17 @@ class DeepseekOCRMultiModalProcessor(
                 prompt=prompt,
                 mm_items=mm_data_items,
                 hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+                tokenization_kwargs=tokenization_kwargs,
+                mm_uuids=mm_uuids,
                 enable_hf_prompt_update=True,
             )
 
         return super()._cached_apply_hf_processor(
-            prompt=prompt,
-            mm_data_items=mm_data_items,
-            hf_processor_mm_kwargs=hf_processor_mm_kwargs,
+            prompt,
+            mm_data_items,
+            hf_processor_mm_kwargs,
+            tokenization_kwargs,
+            mm_uuids=mm_uuids,
         )
 
 
@@ -555,10 +562,8 @@ class DeepseekOCRForCausalLM(nn.Module, SupportsMultiModal, SupportsPP):
     def compute_logits(
         self,
         hidden_states: torch.Tensor,
-        sampling_metadata: SamplingMetadata,
     ) -> Optional[torch.Tensor]:
-        return self.language_model.compute_logits(hidden_states,
-                                                  sampling_metadata)
+        return self.language_model.compute_logits(hidden_states)
 
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]) -> Set[str]:

--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/process/image_process.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/process/image_process.py
@@ -1,11 +1,12 @@
 import math
-from typing import List, Tuple
+from typing import List, Tuple, Mapping, Optional
 
 import torch
 import torchvision.transforms as T
 from PIL import Image, ImageOps
 from transformers import AutoProcessor, BatchFeature, LlamaTokenizerFast
 from transformers.processing_utils import ProcessorMixin
+from vllm.multimodal.processing import MultiModalDataDict, MultiModalUUIDDict
 from config import IMAGE_SIZE, BASE_SIZE, CROP_MODE, MIN_CROPS, MAX_CROPS, PROMPT, TOKENIZER
 
 def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
@@ -297,10 +298,11 @@ class DeepseekOCRProcessor(ProcessorMixin):
 
     def __call__(
         self,
-        *,
         prompt: str,
-        images: List,
-        inference_mode: bool = True,
+        mm_data: MultiModalDataDict,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        *,
+        mm_uuids: Optional[MultiModalUUIDDict] = None,
         **kwargs,
     ):
         """
@@ -318,11 +320,12 @@ class DeepseekOCRProcessor(ProcessorMixin):
                 - image_id (int): the id of the image token
                 - num_image_tokens (List[int]): the number of image tokens
         """
+        images = mm_data.get("image", [])
 
         prepare = self.process_one(
             prompt=prompt,
             images=images,
-            inference_mode=inference_mode,
+            inference_mode=True,
         )
 
         return prepare

--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/run_dpsk_ocr_eval_batch.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/run_dpsk_ocr_eval_batch.py
@@ -4,7 +4,7 @@ from tqdm import tqdm
 import torch
 if torch.version.cuda == '11.8':
     os.environ["TRITON_PTXAS_PATH"] = "/usr/local/cuda-11.8/bin/ptxas"
-os.environ['VLLM_USE_V1'] = '0'
+os.environ['VLLM_USE_V1'] = '1'  # Updated to V1 for compatibility
 os.environ["CUDA_VISIBLE_DEVICES"] = '0'
 
 from config import MODEL_PATH, INPUT_PATH, OUTPUT_PATH, PROMPT, MAX_CONCURRENCY, CROP_MODE, NUM_WORKERS
@@ -16,7 +16,8 @@ from deepseek_ocr import DeepseekOCRForCausalLM
 from vllm.model_executor.models.registry import ModelRegistry
 
 from vllm import LLM, SamplingParams
-from process.ngram_norepeat import NoRepeatNGramLogitsProcessor
+# NOTE: VLLM V1 does not support per-request logits processors
+# from process.ngram_norepeat import NoRepeatNGramLogitsProcessor
 from process.image_process import DeepseekOCRProcessor
 ModelRegistry.register_model("DeepseekOCRForCausalLM", DeepseekOCRForCausalLM)
 
@@ -34,12 +35,14 @@ llm = LLM(
     gpu_memory_utilization=0.9,
 )
 
-logits_processors = [NoRepeatNGramLogitsProcessor(ngram_size=40, window_size=90, whitelist_token_ids= {128821, 128822})] #window for fast；whitelist_token_ids: <td>,</td>
+# NOTE: VLLM V1 does not support per-request logits processors
+# logits_processors = [NoRepeatNGramLogitsProcessor(ngram_size=40, window_size=90, whitelist_token_ids= {128821, 128822})] #window for fast；whitelist_token_ids: <td>,</td>
 
 sampling_params = SamplingParams(
     temperature=0.0,
     max_tokens=8192,
-    logits_processors=logits_processors,
+    # NOTE: Using repetition_penalty instead of custom logits processor for V1 compatibility
+    repetition_penalty=1.05,
     skip_special_tokens=False,
 )
 

--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/run_dpsk_ocr_pdf.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/run_dpsk_ocr_pdf.py
@@ -10,7 +10,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 if torch.version.cuda == '11.8':
     os.environ["TRITON_PTXAS_PATH"] = "/usr/local/cuda-11.8/bin/ptxas"
-os.environ['VLLM_USE_V1'] = '0'
+os.environ['VLLM_USE_V1'] = '1'
 os.environ["CUDA_VISIBLE_DEVICES"] = '0'
 
 
@@ -23,7 +23,8 @@ from deepseek_ocr import DeepseekOCRForCausalLM
 from vllm.model_executor.models.registry import ModelRegistry
 
 from vllm import LLM, SamplingParams
-from process.ngram_norepeat import NoRepeatNGramLogitsProcessor
+# NOTE: VLLM V1 does not support per-request logits processors
+# from process.ngram_norepeat import NoRepeatNGramLogitsProcessor
 from process.image_process import DeepseekOCRProcessor
 
 ModelRegistry.register_model("DeepseekOCRForCausalLM", DeepseekOCRForCausalLM)
@@ -43,12 +44,15 @@ llm = LLM(
     disable_mm_preprocessor_cache=True
 )
 
-logits_processors = [NoRepeatNGramLogitsProcessor(ngram_size=20, window_size=50, whitelist_token_ids= {128821, 128822})] #window for fast；whitelist_token_ids: <td>,</td>
+# NOTE: VLLM V1 does not support per-request logits processors
+# Using repetition_penalty as an alternative to NoRepeatNGramLogitsProcessor
+# logits_processors = [NoRepeatNGramLogitsProcessor(ngram_size=20, window_size=50, whitelist_token_ids= {128821, 128822})]
 
 sampling_params = SamplingParams(
     temperature=0.0,
     max_tokens=8192,
-    logits_processors=logits_processors,
+    # NOTE: Using repetition_penalty instead of custom logits processor for V1 compatibility
+    repetition_penalty=1.05,  # Slight penalty to discourage repetition
     skip_special_tokens=False,
     include_stop_str_in_output=True,
 )

--- a/README.md
+++ b/README.md
@@ -76,14 +76,14 @@ conda activate deepseek-ocr
 ```
 3. Packages
 
-- download the vllm-0.8.5 [whl](https://github.com/vllm-project/vllm/releases/tag/v0.8.5) 
 ```Shell
-pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu118
-pip install vllm-0.8.5+cu118-cp38-abi3-manylinux1_x86_64.whl
 pip install -r requirements.txt
-pip install flash-attn==2.7.3 --no-build-isolation
+pip install transformers
+# vLLM 0.11.0
+pip install https://github.com/vllm-project/vllm/releases/download/v0.11.0/vllm-0.11.0+cu129-cp38-abi3-manylinux1_x86_64.whl
+# Adapt flash-attention for torch2.8 and cuda12
+pip install https://github.com/Dao-AILab/flash-attention/releases/download/v2.8.3/flash_attn-2.8.3+cu12torch2.8cxx11abiTRUE-cp312-cp312-linux_x86_64.whl
 ```
-**Note:** if you want vLLM and transformers codes to run in the same environment, you don't need to worry about this installation error like: vllm 0.8.5+cu118 requires transformers>=4.51.1
 
 ## vLLM-Inference
 - VLLM:


### PR DESCRIPTION
This allows DeepSeek-OCR to run with latest vLLM. I haven't tested if replacing the `NoRepeatNGramLogitsProcessor` with a simple repeat rejection built-in for vLLM will negatively impact the accuracy.

This is required to run DeepSeek-OCR on newer NVIDIA GPU platforms.