### PR TITLE
Update Install guide with wget command for vllm-0.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ conda activate deepseek-ocr
 - download the vllm-0.8.5 [whl](https://github.com/vllm-project/vllm/releases/tag/v0.8.5) 
 ```Shell
 pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu118
+wget https://github.com/vllm-project/vllm/releases/download/v0.8.5/vllm-0.8.5+cu118-cp38-abi3-manylinux1_x86_64.whl
 pip install vllm-0.8.5+cu118-cp38-abi3-manylinux1_x86_64.whl
 pip install -r requirements.txt
 pip install flash-attn==2.7.3 --no-build-isolation


### PR DESCRIPTION
Include the command to download the wheel directly before installation to prevent errors caused by missing wheels.