### PR TITLE
FEAT: Add CLI arguments for inference script

### DIFF
--- a/DeepSeek-OCR-master/DeepSeek-OCR-hf/run_dpsk_ocr.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-hf/run_dpsk_ocr.py
@@ -1,34 +1,36 @@
+import argparse
 from transformers import AutoModel, AutoTokenizer
 import torch
 import os
 
+def main():
+    parser = argparse.ArgumentParser(description="Run DeepSeek-OCR inference.")
+    parser.add_argument("--image_file", type=str, default="your_image.jpg",
+                        help="Path to the input image file.")
+    parser.add_argument("--output_path", type=str, default="your/output/dir",
+                        help="Directory to save the output.")
+    parser.add_argument("--cuda_device", type=str, default="0",
+                        help="CUDA_VISIBLE_DEVICES environment variable value.")
+    args = parser.parse_args()
 
-os.environ["CUDA_VISIBLE_DEVICES"] = '0'
+    os.environ["CUDA_VISIBLE_DEVICES"] = args.cuda_device
 
+    model_name = 'deepseek-ai/DeepSeek-OCR'
 
-model_name = 'deepseek-ai/DeepSeek-OCR'
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    model = AutoModel.from_pretrained(model_name, _attn_implementation='flash_attention_2', trust_remote_code=True, use_safetensors=True)
+    model = model.eval().cuda().to(torch.bfloat16)
 
+    # prompt = "<image>\nFree OCR. "
+    prompt = "<image>\n<|grounding|>Convert the document to markdown. "
 
-tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
-model = AutoModel.from_pretrained(model_name, _attn_implementation='flash_attention_2', trust_remote_code=True, use_safetensors=True)
-model = model.eval().cuda().to(torch.bfloat16)
+    if not os.path.exists(args.image_file):
+        print(f"Error: Image file not found at {args.image_file}")
+        return
 
+    os.makedirs(args.output_path, exist_ok=True)
 
+    res = model.infer(tokenizer, prompt=prompt, image_file=args.image_file, output_path = args.output_path, base_size = 1024, image_size = 640, crop_mode=True, save_results = True, test_compress = True)
 
-# prompt = "<image>\nFree OCR. "
-prompt = "<image>\n<|grounding|>Convert the document to markdown. "
-image_file = 'your_image.jpg'
-output_path = 'your/output/dir'
-
-
-
-# infer(self, tokenizer, prompt='', image_file='', output_path = ' ', base_size = 1024, image_size = 640, crop_mode = True, test_compress = False, save_results = False):
-
-# Tiny: base_size = 512, image_size = 512, crop_mode = False
-# Small: base_size = 640, image_size = 640, crop_mode = False
-# Base: base_size = 1024, image_size = 1024, crop_mode = False
-# Large: base_size = 1280, image_size = 1280, crop_mode = False
-
-# Gundam: base_size = 1024, image_size = 640, crop_mode = True
-
-res = model.infer(tokenizer, prompt=prompt, image_file=image_file, output_path = output_path, base_size = 1024, image_size = 640, crop_mode=True, save_results = True, test_compress = True)
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refactored run_dpsk_ocr.py to accept command-line arguments for image_file, output_path, and CUDA_VISIBLE_DEVICES using argparse. This improves the script's usability and flexibility, allowing users to easily configure inputs and device selection without modifying the code. Added basic error handling for missing image files and ensured output directory creation.