### PR TITLE
feat: Add optional cross-page table merging functionality

### DIFF
--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/config.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/config.py
@@ -16,6 +16,10 @@ PRINT_NUM_VIS_TOKENS = False
 SKIP_REPEAT = True
 MODEL_PATH = 'deepseek-ai/DeepSeek-OCR' # change to your model path
 
+# Cross-page table merging settings
+ENABLE_TABLE_MERGE = False  # Set to True to enable cross-page table merging (default: False for backward compatibility)
+TABLE_MERGE_LOG = True      # Log which tables are merged
+
 # TODO: change INPUT_PATH
 # .pdf: run_dpsk_ocr_pdf.py; 
 # .jpg, .png, .jpeg: run_dpsk_ocr_image.py; 

--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/config.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/config.py
@@ -16,9 +16,10 @@ PRINT_NUM_VIS_TOKENS = False
 SKIP_REPEAT = True
 MODEL_PATH = 'deepseek-ai/DeepSeek-OCR' # change to your model path
 
-# Cross-page table merging settings
-ENABLE_TABLE_MERGE = False  # Set to True to enable cross-page table merging (default: False for backward compatibility)
-TABLE_MERGE_LOG = True      # Log which tables are merged
+# Cross-page table merging
+ENABLE_TABLE_MERGE = False
+ENABLE_HTML_TABLE_MERGE = True
+TABLE_MERGE_LOG = True
 
 # TODO: change INPUT_PATH
 # .pdf: run_dpsk_ocr_pdf.py; 

--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/process/table_merger.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/process/table_merger.py
@@ -1,0 +1,415 @@
+"""
+Table Merger for Cross-Page Tables
+This module detects and merges tables that are split across multiple pages in PDF OCR output.
+"""
+import re
+from typing import List, Tuple, Optional
+
+
+class TableBlock:
+    """Represents a table block in the document."""
+    
+    def __init__(self, content: str, page_num: int, start_pos: int, end_pos: int):
+        self.content = content
+        self.page_num = page_num
+        self.start_pos = start_pos
+        self.end_pos = end_pos
+        self.rows = self._parse_rows()
+        self.is_complete = self._check_completeness()
+        
+    def _parse_rows(self) -> List[str]:
+        """Parse table rows from markdown content."""
+        lines = self.content.strip().split('\n')
+        rows = [line.strip() for line in lines if line.strip().startswith('|')]
+        return rows
+    
+    def _check_completeness(self) -> bool:
+        """Check if table appears complete."""
+        if len(self.rows) < 2:
+            return False
+        
+        has_separator = any(
+            re.match(r'^\|[\s\-:]+\|', row) and set(row.replace('|', '').replace(' ', '').replace(':', '')) <= {'-'}
+            for row in self.rows[:3]
+        )
+        
+        return has_separator
+    
+    def get_column_count(self) -> int:
+        """Get the number of columns in the table."""
+        if not self.rows:
+            return 0
+        return max(row.count('|') - 1 for row in self.rows)
+    
+    def get_header(self) -> Optional[str]:
+        """Get the header row if exists."""
+        if len(self.rows) >= 1:
+            return self.rows[0]
+        return None
+
+
+def extract_tables(content: str) -> List[Tuple[int, int, str]]:
+    """Extract all markdown tables from content."""
+    tables = []
+    lines = content.split('\n')
+    
+    i = 0
+    while i < len(lines):
+        line = lines[i].strip()
+        
+        if line.startswith('|') and '|' in line[1:]:
+            table_start = i
+            table_lines = [lines[i]]
+            i += 1
+            
+            while i < len(lines):
+                next_line = lines[i].strip()
+                if next_line.startswith('|') and '|' in next_line[1:]:
+                    table_lines.append(lines[i])
+                    i += 1
+                elif next_line == '':
+                    lookahead = i + 1
+                    while lookahead < len(lines) and lines[lookahead].strip() == '':
+                        lookahead += 1
+                    
+                    if lookahead < len(lines) and lines[lookahead].strip().startswith('|'):
+                        table_lines.append(lines[i])
+                        i += 1
+                    else:
+                        break
+                else:
+                    break
+            
+            table_content = '\n'.join(table_lines)
+            char_start = sum(len(lines[j]) + 1 for j in range(table_start))
+            char_end = char_start + len(table_content)
+            
+            tables.append((char_start, char_end, table_content))
+        else:
+            i += 1
+    
+    return tables
+
+
+def can_merge_tables(table1: TableBlock, table2: TableBlock) -> bool:
+    """Determine if two tables from consecutive pages can be merged."""
+    if table2.page_num != table1.page_num + 1:
+        return False
+    
+    if table1.get_column_count() != table2.get_column_count():
+        return False
+    
+    if table1.is_complete and table2.is_complete:
+        header1 = table1.get_header()
+        header2 = table2.get_header()
+        
+        if header1 and header2:
+            similarity = _calculate_similarity(header1, header2)
+            if similarity > 0.8:
+                return True
+    
+    if not table1.is_complete:
+        return True
+    
+    if not table2.is_complete and len(table2.rows) > 0:
+        return True
+    
+    return False
+
+
+def merge_tables(table1: TableBlock, table2: TableBlock) -> str:
+    """Merge two tables into one markdown table."""
+    rows1 = table1.rows.copy()
+    rows2 = table2.rows.copy()
+    
+    separator_idx1 = -1
+    for i, row in enumerate(rows1):
+        if re.match(r'^\|[\s\-:]+\|', row) and set(row.replace('|', '').replace(' ', '').replace(':', '')) <= {'-'}:
+            separator_idx1 = i
+            break
+    
+    separator_idx2 = -1
+    for i, row in enumerate(rows2):
+        if re.match(r'^\|[\s\-:]+\|', row) and set(row.replace('|', '').replace(' ', '').replace(':', '')) <= {'-'}:
+            separator_idx2 = i
+            break
+    
+    merged_rows = []
+    
+    if separator_idx1 >= 0:
+        merged_rows.extend(rows1[:separator_idx1 + 1])
+        merged_rows.extend(rows1[separator_idx1 + 1:])
+    else:
+        merged_rows.extend(rows1)
+    
+    if separator_idx2 >= 0:
+        merged_rows.extend(rows2[separator_idx2 + 1:])
+    else:
+        if len(rows2) > 0 and len(rows1) > 0:
+            similarity = _calculate_similarity(rows1[0], rows2[0])
+            if similarity > 0.8:
+                merged_rows.extend(rows2[1:])
+            else:
+                merged_rows.extend(rows2)
+        else:
+            merged_rows.extend(rows2)
+    
+    return '\n'.join(merged_rows)
+
+
+def _calculate_similarity(str1: str, str2: str) -> float:
+    """Calculate similarity between two strings."""
+    if not str1 or not str2:
+        return 0.0
+    
+    s1 = ' '.join(str1.lower().split())
+    s2 = ' '.join(str2.lower().split())
+    
+    if s1 == s2:
+        return 1.0
+    
+    set1 = set(s1)
+    set2 = set(s2)
+    intersection = len(set1 & set2)
+    union = len(set1 | set2)
+    
+    return intersection / union if union > 0 else 0.0
+
+
+def merge_cross_page_tables(pages_content: List[str]) -> List[str]:
+    """Main function to merge cross-page tables in PDF OCR output."""
+    all_tables = []
+    for page_num, page_content in enumerate(pages_content):
+        tables = extract_tables(page_content)
+        for start_pos, end_pos, table_content in tables:
+            table_block = TableBlock(table_content, page_num, start_pos, end_pos)
+            all_tables.append(table_block)
+    
+    merge_groups = []
+    merged_indices = set()
+    
+    for i in range(len(all_tables) - 1):
+        if i in merged_indices:
+            continue
+            
+        current_group = [i]
+        j = i + 1
+        
+        while j < len(all_tables):
+            if can_merge_tables(all_tables[current_group[-1]], all_tables[j]):
+                current_group.append(j)
+                merged_indices.add(j)
+                j += 1
+            else:
+                break
+        
+        if len(current_group) > 1:
+            merge_groups.append(current_group)
+            merged_indices.add(i)
+    
+    result_pages = []
+    
+    for page_num, page_content in enumerate(pages_content):
+        page_tables = [t for t in all_tables if t.page_num == page_num]
+        
+        if not page_tables:
+            result_pages.append(page_content)
+            continue
+        
+        modified_content = page_content
+        
+        for table in sorted(page_tables, key=lambda t: t.start_pos, reverse=True):
+            table_idx = all_tables.index(table)
+            
+            merge_group = None
+            for group in merge_groups:
+                if table_idx in group:
+                    merge_group = group
+                    break
+            
+            if merge_group and table_idx == merge_group[0]:
+                tables_to_merge = [all_tables[idx] for idx in merge_group]
+                merged_table = tables_to_merge[0].content
+                
+                for next_table in tables_to_merge[1:]:
+                    merged_table = merge_tables(
+                        TableBlock(merged_table, 0, 0, 0),
+                        next_table
+                    )
+                
+                modified_content = (
+                    modified_content[:table.start_pos] +
+                    merged_table +
+                    modified_content[table.end_pos:]
+                )
+            elif merge_group and table_idx in merge_group[1:]:
+                modified_content = (
+                    modified_content[:table.start_pos] +
+                    modified_content[table.end_pos:]
+                )
+        
+        result_pages.append(modified_content)
+    
+    return result_pages
+
+
+def process_pdf_output(content: str, page_separator: str = '<--- Page Split --->') -> str:
+    """Process complete PDF OCR output and merge cross-page tables."""
+    pages = content.split(f'\n{page_separator}\n')
+    merged_pages = merge_cross_page_tables(pages)
+    return f'\n{page_separator}\n'.join(merged_pages)
+
+
+def process_pdf_output_with_stats(content: str, page_separator: str = '<--- Page Split --->') -> Tuple[str, dict]:
+    """
+    Process complete PDF OCR output and merge cross-page tables with statistics.
+    
+    Returns:
+        Tuple of (merged_content, statistics_dict)
+        
+    Statistics dict contains:
+        - total_tables: Total number of tables found
+        - merged_count: Number of table groups that were merged
+        - details: List of merge details with page numbers and previews
+    """
+    pages = content.split(f'\n{page_separator}\n')
+    
+    # Parse all tables
+    all_tables = []
+    for page_num, page_content in enumerate(pages):
+        tables = extract_tables(page_content)
+        for start_pos, end_pos, table_content in tables:
+            table_block = TableBlock(table_content, page_num, start_pos, end_pos)
+            all_tables.append(table_block)
+    
+    # Identify tables to merge
+    merge_groups = []
+    merged_indices = set()
+    
+    for i in range(len(all_tables) - 1):
+        if i in merged_indices:
+            continue
+            
+        current_group = [i]
+        j = i + 1
+        
+        while j < len(all_tables):
+            if can_merge_tables(all_tables[current_group[-1]], all_tables[j]):
+                current_group.append(j)
+                merged_indices.add(j)
+                j += 1
+            else:
+                break
+        
+        if len(current_group) > 1:
+            merge_groups.append(current_group)
+            merged_indices.add(i)
+    
+    # Merge tables
+    merged_pages = merge_cross_page_tables(pages)
+    merged_content = f'\n{page_separator}\n'.join(merged_pages)
+    
+    # Build statistics
+    stats = {
+        'total_tables': len(all_tables),
+        'merged_count': len(merge_groups),
+        'details': []
+    }
+    
+    for group in merge_groups:
+        first_table = all_tables[group[0]]
+        last_table = all_tables[group[-1]]
+        header = first_table.get_header() or 'Unknown table'
+        # Truncate header for preview
+        header_preview = header[:50] + '...' if len(header) > 50 else header
+        
+        stats['details'].append({
+            'from_page': first_table.page_num + 1,  # 1-indexed for user display
+            'to_page': last_table.page_num + 1,
+            'table_count': len(group),
+            'table_preview': header_preview
+        })
+    
+    return merged_content, stats
+
+
+def extract_html_tables(content: str) -> List[Tuple[int, int, str]]:
+    """
+    Extract HTML format tables from content.
+    Returns list of (start_pos, end_pos, table_content).
+    """
+    import re
+    tables = []
+    
+    # Pattern to match <table>...</table> including attributes
+    pattern = r'<table[^>]*>.*?</table>'
+    
+    for match in re.finditer(pattern, content, re.DOTALL | re.IGNORECASE):
+        start_pos = match.start()
+        end_pos = match.end()
+        table_content = match.group(0)
+        tables.append((start_pos, end_pos, table_content))
+    
+    return tables
+
+
+class HTMLTableBlock:
+    """Represents an HTML table block in the document."""
+    
+    def __init__(self, content: str, page_num: int, start_pos: int, end_pos: int):
+        self.content = content
+        self.page_num = page_num
+        self.start_pos = start_pos
+        self.end_pos = end_pos
+        self.rows = self._parse_rows()
+        
+    def _parse_rows(self) -> List[str]:
+        """Parse table rows from HTML content."""
+        import re
+        # Extract all <tr>...</tr> blocks
+        tr_pattern = r'<tr[^>]*>.*?</tr>'
+        rows = re.findall(tr_pattern, self.content, re.DOTALL | re.IGNORECASE)
+        return rows
+    
+    def get_column_count(self) -> int:
+        """Get the number of columns by counting <td> or <th> in first row."""
+        if not self.rows:
+            return 0
+        import re
+        # Count <td> and <th> tags
+        td_count = len(re.findall(r'<td[^>]*>', self.rows[0], re.IGNORECASE))
+        th_count = len(re.findall(r'<th[^>]*>', self.rows[0], re.IGNORECASE))
+        return max(td_count, th_count)
+
+
+def can_merge_html_tables(table1: HTMLTableBlock, table2: HTMLTableBlock) -> bool:
+    """Determine if two HTML tables from consecutive pages can be merged."""
+    if table2.page_num != table1.page_num + 1:
+        return False
+    
+    if table1.get_column_count() != table2.get_column_count():
+        return False
+    
+    # HTML tables are easier - just check column count and page adjacency
+    return True
+
+
+def merge_html_tables(table1: HTMLTableBlock, table2: HTMLTableBlock) -> str:
+    """Merge two HTML tables."""
+    import re
+    
+    # Extract opening tag from table1
+    table1_opening = re.match(r'<table[^>]*>', table1.content, re.IGNORECASE).group(0)
+    
+    # Extract all rows
+    rows1 = table1.rows
+    rows2 = table2.rows
+    
+    # Combine rows
+    all_rows = rows1 + rows2
+    
+    # Reconstruct table
+    merged_table = table1_opening + '\n' + '\n'.join(all_rows) + '\n</table>'
+    
+    return merged_table
+

--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/process/table_merger.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/process/table_merger.py
@@ -1,14 +1,8 @@
-"""
-Table Merger for Cross-Page Tables
-This module detects and merges tables that are split across multiple pages in PDF OCR output.
-"""
 import re
-from typing import List, Tuple, Optional
+from typing import List, Tuple, Optional, Dict
 
 
 class TableBlock:
-    """Represents a table block in the document."""
-    
     def __init__(self, content: str, page_num: int, start_pos: int, end_pos: int):
         self.content = content
         self.page_num = page_num
@@ -18,38 +12,34 @@ class TableBlock:
         self.is_complete = self._check_completeness()
         
     def _parse_rows(self) -> List[str]:
-        """Parse table rows from markdown content."""
         lines = self.content.strip().split('\n')
         rows = [line.strip() for line in lines if line.strip().startswith('|')]
         return rows
     
     def _check_completeness(self) -> bool:
-        """Check if table appears complete."""
         if len(self.rows) < 2:
             return False
         
         has_separator = any(
-            re.match(r'^\|[\s\-:]+\|', row) and set(row.replace('|', '').replace(' ', '').replace(':', '')) <= {'-'}
+            re.match(r'^\|[\s\-:]+\|', row) and 
+            set(row.replace('|', '').replace(' ', '').replace(':', '')) <= {'-'}
             for row in self.rows[:3]
         )
         
         return has_separator
     
     def get_column_count(self) -> int:
-        """Get the number of columns in the table."""
         if not self.rows:
             return 0
         return max(row.count('|') - 1 for row in self.rows)
     
     def get_header(self) -> Optional[str]:
-        """Get the header row if exists."""
         if len(self.rows) >= 1:
             return self.rows[0]
         return None
 
 
 def extract_tables(content: str) -> List[Tuple[int, int, str]]:
-    """Extract all markdown tables from content."""
     tables = []
     lines = content.split('\n')
     
@@ -81,7 +71,7 @@ def extract_tables(content: str) -> List[Tuple[int, int, str]]:
                     break
             
             table_content = '\n'.join(table_lines)
-            char_start = sum(len(lines[j]) + 1 for j in range(table_start))
+            char_start = sum(len(line) + 1 for line in lines[:table_start])
             char_end = char_start + len(table_content)
             
             tables.append((char_start, char_end, table_content))
@@ -91,121 +81,107 @@ def extract_tables(content: str) -> List[Tuple[int, int, str]]:
     return tables
 
 
+def _calculate_similarity(str1: str, str2: str) -> float:
+    if not str1 or not str2:
+        return 0.0
+    
+    str1_clean = re.sub(r'[^a-zA-Z0-9]', '', str1.lower())
+    str2_clean = re.sub(r'[^a-zA-Z0-9]', '', str2.lower())
+    
+    if not str1_clean or not str2_clean:
+        return 0.0
+    
+    matches = sum(1 for a, b in zip(str1_clean, str2_clean) if a == b)
+    max_len = max(len(str1_clean), len(str2_clean))
+    
+    return matches / max_len if max_len > 0 else 0.0
+
+
 def can_merge_tables(table1: TableBlock, table2: TableBlock) -> bool:
-    """Determine if two tables from consecutive pages can be merged."""
     if table2.page_num != table1.page_num + 1:
         return False
     
     if table1.get_column_count() != table2.get_column_count():
         return False
     
-    if table1.is_complete and table2.is_complete:
-        header1 = table1.get_header()
-        header2 = table2.get_header()
-        
-        if header1 and header2:
-            similarity = _calculate_similarity(header1, header2)
-            if similarity > 0.8:
-                return True
-    
     if not table1.is_complete:
         return True
     
-    if not table2.is_complete and len(table2.rows) > 0:
-        return True
+    header1 = table1.get_header()
+    header2 = table2.get_header()
+    
+    if header1 and header2:
+        similarity = _calculate_similarity(header1, header2)
+        return similarity >= 0.8
     
     return False
 
 
 def merge_tables(table1: TableBlock, table2: TableBlock) -> str:
-    """Merge two tables into one markdown table."""
     rows1 = table1.rows.copy()
     rows2 = table2.rows.copy()
     
-    separator_idx1 = -1
-    for i, row in enumerate(rows1):
-        if re.match(r'^\|[\s\-:]+\|', row) and set(row.replace('|', '').replace(' ', '').replace(':', '')) <= {'-'}:
-            separator_idx1 = i
-            break
+    has_separator2 = any(
+        set(row.replace('|', '').replace(' ', '').replace(':', '')) <= {'-'}
+        for row in rows2[:3]
+    )
     
-    separator_idx2 = -1
-    for i, row in enumerate(rows2):
-        if re.match(r'^\|[\s\-:]+\|', row) and set(row.replace('|', '').replace(' ', '').replace(':', '')) <= {'-'}:
-            separator_idx2 = i
-            break
+    if has_separator2:
+        rows2 = [row for row in rows2 if not (
+            set(row.replace('|', '').replace(' ', '').replace(':', '')) <= {'-'}
+        )]
     
-    merged_rows = []
+    header1 = rows1[0] if rows1 else None
+    header2 = rows2[0] if rows2 else None
     
-    if separator_idx1 >= 0:
-        merged_rows.extend(rows1[:separator_idx1 + 1])
-        merged_rows.extend(rows1[separator_idx1 + 1:])
-    else:
-        merged_rows.extend(rows1)
+    if header1 and header2:
+        similarity = _calculate_similarity(header1, header2)
+        if similarity >= 0.8:
+            rows2 = rows2[1:]
     
-    if separator_idx2 >= 0:
-        merged_rows.extend(rows2[separator_idx2 + 1:])
-    else:
-        if len(rows2) > 0 and len(rows1) > 0:
-            similarity = _calculate_similarity(rows1[0], rows2[0])
-            if similarity > 0.8:
-                merged_rows.extend(rows2[1:])
-            else:
-                merged_rows.extend(rows2)
-        else:
-            merged_rows.extend(rows2)
-    
+    merged_rows = rows1 + rows2
     return '\n'.join(merged_rows)
 
 
-def _calculate_similarity(str1: str, str2: str) -> float:
-    """Calculate similarity between two strings."""
-    if not str1 or not str2:
-        return 0.0
-    
-    s1 = ' '.join(str1.lower().split())
-    s2 = ' '.join(str2.lower().split())
-    
-    if s1 == s2:
-        return 1.0
-    
-    set1 = set(s1)
-    set2 = set(s2)
-    intersection = len(set1 & set2)
-    union = len(set1 | set2)
-    
-    return intersection / union if union > 0 else 0.0
-
-
-def merge_cross_page_tables(pages_content: List[str]) -> List[str]:
-    """Main function to merge cross-page tables in PDF OCR output."""
+def _parse_all_tables(pages_content: List[str]) -> List[TableBlock]:
     all_tables = []
+    
     for page_num, page_content in enumerate(pages_content):
-        tables = extract_tables(page_content)
-        for start_pos, end_pos, table_content in tables:
+        tables_in_page = extract_tables(page_content)
+        
+        for start_pos, end_pos, table_content in tables_in_page:
             table_block = TableBlock(table_content, page_num, start_pos, end_pos)
             all_tables.append(table_block)
     
+    return all_tables
+
+
+def _identify_merge_groups(all_tables: List[TableBlock]) -> List[List[int]]:
     merge_groups = []
-    merged_indices = set()
+    i = 0
     
-    for i in range(len(all_tables) - 1):
-        if i in merged_indices:
-            continue
-            
+    while i < len(all_tables):
         current_group = [i]
-        j = i + 1
         
+        j = i + 1
         while j < len(all_tables):
             if can_merge_tables(all_tables[current_group[-1]], all_tables[j]):
                 current_group.append(j)
-                merged_indices.add(j)
                 j += 1
             else:
                 break
         
         if len(current_group) > 1:
             merge_groups.append(current_group)
-            merged_indices.add(i)
+        
+        i = current_group[-1] + 1
+    
+    return merge_groups
+
+
+def merge_cross_page_tables(pages_content: List[str]) -> List[str]:
+    all_tables = _parse_all_tables(pages_content)
+    merge_groups = _identify_merge_groups(all_tables)
     
     result_pages = []
     
@@ -254,65 +230,34 @@ def merge_cross_page_tables(pages_content: List[str]) -> List[str]:
 
 
 def process_pdf_output(content: str, page_separator: str = '<--- Page Split --->') -> str:
-    """Process complete PDF OCR output and merge cross-page tables."""
     pages = content.split(f'\n{page_separator}\n')
     merged_pages = merge_cross_page_tables(pages)
+    
+    try:
+        from config import ENABLE_HTML_TABLE_MERGE
+        if ENABLE_HTML_TABLE_MERGE:
+            merged_pages = merge_cross_page_html_tables(merged_pages)
+    except:
+        pass
+    
     return f'\n{page_separator}\n'.join(merged_pages)
 
 
-def process_pdf_output_with_stats(content: str, page_separator: str = '<--- Page Split --->') -> Tuple[str, dict]:
-    """
-    Process complete PDF OCR output and merge cross-page tables with statistics.
-    
-    Returns:
-        Tuple of (merged_content, statistics_dict)
-        
-    Statistics dict contains:
-        - total_tables: Total number of tables found
-        - merged_count: Number of table groups that were merged
-        - details: List of merge details with page numbers and previews
-    """
+def process_pdf_output_with_stats(content: str, page_separator: str = '<--- Page Split --->') -> Tuple[str, Dict]:
     pages = content.split(f'\n{page_separator}\n')
     
-    # Parse all tables
-    all_tables = []
-    for page_num, page_content in enumerate(pages):
-        tables = extract_tables(page_content)
-        for start_pos, end_pos, table_content in tables:
-            table_block = TableBlock(table_content, page_num, start_pos, end_pos)
-            all_tables.append(table_block)
+    all_tables = _parse_all_tables(pages)
+    merge_groups = _identify_merge_groups(all_tables)
     
-    # Identify tables to merge
-    merge_groups = []
-    merged_indices = set()
-    
-    for i in range(len(all_tables) - 1):
-        if i in merged_indices:
-            continue
-            
-        current_group = [i]
-        j = i + 1
-        
-        while j < len(all_tables):
-            if can_merge_tables(all_tables[current_group[-1]], all_tables[j]):
-                current_group.append(j)
-                merged_indices.add(j)
-                j += 1
-            else:
-                break
-        
-        if len(current_group) > 1:
-            merge_groups.append(current_group)
-            merged_indices.add(i)
-    
-    # Merge tables
     merged_pages = merge_cross_page_tables(pages)
-    merged_content = f'\n{page_separator}\n'.join(merged_pages)
     
-    # Build statistics
     stats = {
-        'total_tables': len(all_tables),
+        'total_markdown_tables': len(all_tables),
+        'markdown_merged_count': len(merge_groups),
+        'total_html_tables': 0,
+        'html_merged_count': 0,
         'merged_count': len(merge_groups),
+        'total_tables': len(all_tables),
         'details': []
     }
     
@@ -320,28 +265,52 @@ def process_pdf_output_with_stats(content: str, page_separator: str = '<--- Page
         first_table = all_tables[group[0]]
         last_table = all_tables[group[-1]]
         header = first_table.get_header() or 'Unknown table'
-        # Truncate header for preview
         header_preview = header[:50] + '...' if len(header) > 50 else header
         
         stats['details'].append({
-            'from_page': first_table.page_num + 1,  # 1-indexed for user display
+            'type': 'markdown',
+            'from_page': first_table.page_num + 1,
             'to_page': last_table.page_num + 1,
             'table_count': len(group),
             'table_preview': header_preview
         })
     
+    try:
+        from config import ENABLE_HTML_TABLE_MERGE
+        if ENABLE_HTML_TABLE_MERGE:
+            html_tables = _parse_html_tables(merged_pages)
+            html_merge_groups = _identify_html_merge_groups(html_tables)
+            merged_pages = merge_cross_page_html_tables(merged_pages)
+            
+            stats['total_html_tables'] = len(html_tables)
+            stats['html_merged_count'] = len(html_merge_groups)
+            stats['merged_count'] += len(html_merge_groups)
+            stats['total_tables'] = stats['total_markdown_tables'] + len(html_tables)
+            
+            for group in html_merge_groups:
+                first_table = html_tables[group[0]]
+                last_table = html_tables[group[-1]]
+                preview = first_table.rows[0] if first_table.rows else 'HTML table'
+                preview = preview[:50] + '...' if len(preview) > 50 else preview
+                
+                stats['details'].append({
+                    'type': 'html',
+                    'from_page': first_table.page_num + 1,
+                    'to_page': last_table.page_num + 1,
+                    'table_count': len(group),
+                    'table_preview': preview
+                })
+    except:
+        pass
+    
+    merged_content = f'\n{page_separator}\n'.join(merged_pages)
     return merged_content, stats
 
 
+# HTML table processing
 def extract_html_tables(content: str) -> List[Tuple[int, int, str]]:
-    """
-    Extract HTML format tables from content.
-    Returns list of (start_pos, end_pos, table_content).
-    """
     import re
     tables = []
-    
-    # Pattern to match <table>...</table> including attributes
     pattern = r'<table[^>]*>.*?</table>'
     
     for match in re.finditer(pattern, content, re.DOTALL | re.IGNORECASE):
@@ -354,8 +323,6 @@ def extract_html_tables(content: str) -> List[Tuple[int, int, str]]:
 
 
 class HTMLTableBlock:
-    """Represents an HTML table block in the document."""
-    
     def __init__(self, content: str, page_num: int, start_pos: int, end_pos: int):
         self.content = content
         self.page_num = page_num
@@ -364,52 +331,134 @@ class HTMLTableBlock:
         self.rows = self._parse_rows()
         
     def _parse_rows(self) -> List[str]:
-        """Parse table rows from HTML content."""
         import re
-        # Extract all <tr>...</tr> blocks
         tr_pattern = r'<tr[^>]*>.*?</tr>'
         rows = re.findall(tr_pattern, self.content, re.DOTALL | re.IGNORECASE)
         return rows
     
     def get_column_count(self) -> int:
-        """Get the number of columns by counting <td> or <th> in first row."""
         if not self.rows:
             return 0
         import re
-        # Count <td> and <th> tags
         td_count = len(re.findall(r'<td[^>]*>', self.rows[0], re.IGNORECASE))
         th_count = len(re.findall(r'<th[^>]*>', self.rows[0], re.IGNORECASE))
         return max(td_count, th_count)
 
 
 def can_merge_html_tables(table1: HTMLTableBlock, table2: HTMLTableBlock) -> bool:
-    """Determine if two HTML tables from consecutive pages can be merged."""
     if table2.page_num != table1.page_num + 1:
         return False
     
     if table1.get_column_count() != table2.get_column_count():
         return False
     
-    # HTML tables are easier - just check column count and page adjacency
     return True
 
 
 def merge_html_tables(table1: HTMLTableBlock, table2: HTMLTableBlock) -> str:
-    """Merge two HTML tables."""
     import re
     
-    # Extract opening tag from table1
-    table1_opening = re.match(r'<table[^>]*>', table1.content, re.IGNORECASE).group(0)
+    table_opening_match = re.match(r'<table[^>]*>', table1.content, re.IGNORECASE)
+    if not table_opening_match:
+        return table1.content
     
-    # Extract all rows
+    table1_opening = table_opening_match.group(0)
     rows1 = table1.rows
     rows2 = table2.rows
-    
-    # Combine rows
     all_rows = rows1 + rows2
     
-    # Reconstruct table
     merged_table = table1_opening + '\n' + '\n'.join(all_rows) + '\n</table>'
-    
     return merged_table
 
+
+def _parse_html_tables(pages_content: List[str]) -> List[HTMLTableBlock]:
+    html_tables = []
+    
+    for page_num, page_content in enumerate(pages_content):
+        tables_in_page = extract_html_tables(page_content)
+        
+        for start_pos, end_pos, table_content in tables_in_page:
+            html_table = HTMLTableBlock(table_content, page_num, start_pos, end_pos)
+            html_tables.append(html_table)
+    
+    return html_tables
+
+
+def _identify_html_merge_groups(html_tables: List[HTMLTableBlock]) -> List[List[int]]:
+    merge_groups = []
+    i = 0
+    
+    while i < len(html_tables):
+        current_group = [i]
+        
+        j = i + 1
+        while j < len(html_tables):
+            if can_merge_html_tables(html_tables[current_group[-1]], html_tables[j]):
+                current_group.append(j)
+                j += 1
+            else:
+                break
+        
+        if len(current_group) > 1:
+            merge_groups.append(current_group)
+        
+        i = current_group[-1] + 1
+    
+    return merge_groups
+
+
+def merge_cross_page_html_tables(pages_content: List[str]) -> List[str]:
+    html_tables = _parse_html_tables(pages_content)
+    
+    if not html_tables:
+        return pages_content
+    
+    merge_groups = _identify_html_merge_groups(html_tables)
+    
+    if not merge_groups:
+        return pages_content
+    
+    result_pages = []
+    
+    for page_num, page_content in enumerate(pages_content):
+        page_html_tables = [t for t in html_tables if t.page_num == page_num]
+        
+        if not page_html_tables:
+            result_pages.append(page_content)
+            continue
+        
+        modified_content = page_content
+        
+        for table in sorted(page_html_tables, key=lambda t: t.start_pos, reverse=True):
+            table_idx = html_tables.index(table)
+            
+            merge_group = None
+            for group in merge_groups:
+                if table_idx in group:
+                    merge_group = group
+                    break
+            
+            if merge_group and table_idx == merge_group[0]:
+                tables_to_merge = [html_tables[idx] for idx in merge_group]
+                merged_table = tables_to_merge[0].content
+                
+                for next_table in tables_to_merge[1:]:
+                    merged_table = merge_html_tables(
+                        HTMLTableBlock(merged_table, 0, 0, 0),
+                        next_table
+                    )
+                
+                modified_content = (
+                    modified_content[:table.start_pos] +
+                    merged_table +
+                    modified_content[table.end_pos:]
+                )
+            elif merge_group and table_idx in merge_group[1:]:
+                modified_content = (
+                    modified_content[:table.start_pos] +
+                    modified_content[table.end_pos:]
+                )
+        
+        result_pages.append(modified_content)
+    
+    return result_pages

--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/run_dpsk_ocr_pdf.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/run_dpsk_ocr_pdf.py
@@ -320,7 +320,6 @@ if __name__ == "__main__":
 
         jdx += 1
 
-    # Apply cross-page table merging (optional, controlled by config)
     if ENABLE_TABLE_MERGE:
         print(f'{Colors.YELLOW}Cross-page table merging enabled...{Colors.RESET}')
         try:
@@ -355,9 +354,4 @@ if __name__ == "__main__":
 
 
     pil_to_pdf_img2pdf(draw_images, pdf_out_path)
-    
-    completion_msg = 'Processing complete!'
-    if ENABLE_TABLE_MERGE:
-        completion_msg += ' (with cross-page table merging)'
-    print(f'{Colors.GREEN}{completion_msg}{Colors.RESET}')
 

--- a/DeepSeek-OCR-master/DeepSeek-OCR-vllm/run_dpsk_ocr_pdf.py
+++ b/DeepSeek-OCR-master/DeepSeek-OCR-vllm/run_dpsk_ocr_pdf.py
@@ -14,7 +14,7 @@ os.environ['VLLM_USE_V1'] = '0'
 os.environ["CUDA_VISIBLE_DEVICES"] = '0'
 
 
-from config import MODEL_PATH, INPUT_PATH, OUTPUT_PATH, PROMPT, SKIP_REPEAT, MAX_CONCURRENCY, NUM_WORKERS, CROP_MODE
+from config import MODEL_PATH, INPUT_PATH, OUTPUT_PATH, PROMPT, SKIP_REPEAT, MAX_CONCURRENCY, NUM_WORKERS, CROP_MODE, ENABLE_TABLE_MERGE, TABLE_MERGE_LOG
 
 from PIL import Image, ImageDraw, ImageFont
 import numpy as np
@@ -25,6 +25,7 @@ from vllm.model_executor.models.registry import ModelRegistry
 from vllm import LLM, SamplingParams
 from process.ngram_norepeat import NoRepeatNGramLogitsProcessor
 from process.image_process import DeepseekOCRProcessor
+from process.table_merger import process_pdf_output
 
 ModelRegistry.register_model("DeepseekOCRForCausalLM", DeepseekOCRForCausalLM)
 
@@ -319,12 +320,44 @@ if __name__ == "__main__":
 
         jdx += 1
 
+    # Apply cross-page table merging (optional, controlled by config)
+    if ENABLE_TABLE_MERGE:
+        print(f'{Colors.YELLOW}Cross-page table merging enabled...{Colors.RESET}')
+        try:
+            from process.table_merger import process_pdf_output_with_stats
+            contents_merged, merge_stats = process_pdf_output_with_stats(contents)
+            contents_det_merged, merge_stats_det = process_pdf_output_with_stats(contents_det)
+            
+            if TABLE_MERGE_LOG and merge_stats['merged_count'] > 0:
+                print(f'{Colors.GREEN}✓ Merged {merge_stats["merged_count"]} table group(s) across pages{Colors.RESET}')
+                log_path = output_path + '/table_merge_log.txt'
+                with open(log_path, 'w', encoding='utf-8') as log_file:
+                    log_file.write(f"Table Merge Statistics:\n")
+                    log_file.write(f"- Total tables found: {merge_stats['total_tables']}\n")
+                    log_file.write(f"- Merged groups: {merge_stats['merged_count']}\n")
+                    log_file.write(f"- Merged table details:\n")
+                    for detail in merge_stats['details']:
+                        log_file.write(f"  * Pages {detail['from_page']}-{detail['to_page']}: {detail['table_preview']}\n")
+        except Exception as e:
+            print(f'{Colors.RED}Warning: Table merging failed: {e}{Colors.RESET}')
+            print(f'{Colors.YELLOW}Continuing with original output...{Colors.RESET}')
+            contents_merged = contents
+            contents_det_merged = contents_det
+    else:
+        contents_merged = contents
+        contents_det_merged = contents_det
+
     with open(mmd_det_path, 'w', encoding='utf-8') as afile:
-        afile.write(contents_det)
+        afile.write(contents_det_merged)
 
     with open(mmd_path, 'w', encoding='utf-8') as afile:
-        afile.write(contents)
+        afile.write(contents_merged)
 
 
     pil_to_pdf_img2pdf(draw_images, pdf_out_path)
+    
+    completion_msg = 'Processing complete!'
+    if ENABLE_TABLE_MERGE:
+        completion_msg += ' (with cross-page table merging)'
+    print(f'{Colors.GREEN}{completion_msg}{Colors.RESET}')
 


### PR DESCRIPTION
### Summary

Implements optional table merging for tables spanning multiple pages. Currently disabled by default to ensure backward compatibility.

### Related Issye

#131

### Solution

- Added post-processing to merge Markdown and HTML tables from consecutive pages
- Merges based on column count and header similarity (≥80% for Markdown)
- Graceful fallback if merging fails

### Changes

**Modified:**
- `config.py` - Added `ENABLE_TABLE_MERGE`, `ENABLE_HTML_TABLE_MERGE`, `TABLE_MERGE_LOG` flags
- `run_dpsk_ocr_pdf.py` - Integrated optional merge post-processing

**Added:**
- `process/table_merger.py` - Table extraction, parsing, and merge logic

### Features

- Backward compatible (disabled by default)
- No new dependencies
- Supports Markdown and HTML tables
- Error handling with fallback

### Usage

Enable in `config.py`:
```python
ENABLE_TABLE_MERGE = True
```

